### PR TITLE
docs: rename repo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,8 +4,8 @@ We are glad you are reading this. We welcome your contribution.
 
 Here are some important resources:
 
-* [Known Issues](https://github.com/TACC/Core-Docs/issues)
-* [Active Proposals](https://github.com/TACC/Core-Docs/pulls)
+* [Known Issues](https://github.com/TACC/mkdocs-tacc/issues)
+* [Active Proposals](https://github.com/TACC/mkdocs-tacc/pulls)
 * [How to Test](./TESTING.md)
 
 ## Step by Step

--- a/DEPLOYING.md
+++ b/DEPLOYING.md
@@ -6,7 +6,7 @@ Deploys rely on [GitHub Pages](https://pages.github.com/) and [MkDocs command `g
     ```shell
     poetry run mkdocs gh-deploy --force --theme tacc_readthedocs
     ```
-2. Wait for [GitHub action](https://github.com/TACC/Core-Docs/actions) to complete.
+2. Wait for [GitHub action](https://github.com/TACC/mkdocs-tacc/actions) to complete.
 3. Load https://tacc.github.io/Core-Docs/.
 
 # Related

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -13,7 +13,7 @@
 Clone this repository, install all dependencies, activate virtual environment, serve the documentation, e.g.
 
 ```shell
-git clone https://github.com/TACC/Core-Docs.git
+git clone https://github.com/TACC/mkdocs-tacc.git
 cd Core-Docs
 poetry install --sync --all-extras
 poetry run mkdocs serve
@@ -23,7 +23,7 @@ poetry run mkdocs serve
 > If you don't have Poetry installed, you may use `pip`, but we offer no peer support for this approach:
 >
 > ```shell
-> git clone https://github.com/TACC/Core-Docs.git
+> git clone https://github.com/TACC/mkdocs-tacc.git
 > cd Core-Docs
 > python -m venv venv
 > source venv/bin/activate  # On Windows, use: venv\Scripts\activate

--- a/docs/configure.md
+++ b/docs/configure.md
@@ -79,7 +79,7 @@ The theme can change some of the default English text via optional international
 | - | - | - |
 | "Edit on %(repo_name)s" | "Suggest an update via %(repo_name)s" | more accurately reflects contribution workflow of public repositories |
 
-To enable [all text changes](https://github.com/TACC/Core-Docs/main/tacc_readthedocs/locales/en/LC_MESSAGES/messages.po), install the theme with the i18n extra:
+To enable [all text changes](https://github.com/TACC/mkdocs-tacc/main/tacc_readthedocs/locales/en/LC_MESSAGES/messages.po), install the theme with the i18n extra:
 
 | PIP | Poetry |
 | - | - |
@@ -90,5 +90,5 @@ If you install without the i18n extra, the default text "Edit on %(repo_name)s" 
 ## More Options
 
 - [MkDocs: User Guide: Configuration](https://www.mkdocs.org/user-guide/configuration/){target="_blank"}
-- [TACC/Core-Docs: Customization](customize.md)
-- [TACC/Core-Docs: Supported Extensions](extensions.md)
+- [TACC/mkdocs-tacc: Customization](customize.md)
+- [TACC/mkdocs-tacc: Supported Extensions](extensions.md)

--- a/docs/customize.md
+++ b/docs/customize.md
@@ -56,5 +56,5 @@ To override a template:
 ## More Options
 
 - [MkDocs: User Guide: Customizing Your Theme](https://www.mkdocs.org/user-guide/customizing-your-theme/){target="_blank"}
-- [TACC/Core-Docs: Configuration](configure.md)
-- [TACC/Core-Docs: Supported Extensions](extensions.md)
+- [TACC/mkdocs-tacc: Configuration](configure.md)
+- [TACC/mkdocs-tacc: Supported Extensions](extensions.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,7 +2,7 @@ site_name: TACC MkDocs Theme
 site_description: Styles for TACC Documentation
 site_author: Wesley Bomar
 # site_url: https://docs.tacc.utexas.edu
-repo_url: https://github.com/TACC/Core-Docs
+repo_url: https://github.com/TACC/mkdocs-tacc
 edit_uri: edit/main/docs/
 
 theme:
@@ -13,8 +13,8 @@ theme:
   # "ReadTheDocs" Theme Features
   logo: img/logo.svg
   # "TACC" Theme Features
-  cms_url: https://github.com/TACC/Core-Docs
-  cms_name: TACC/Core-Docs
+  cms_url: https://github.com/TACC/mkdocs-tacc
+  cms_name: TACC/mkdocs-tacc
 
 nav:
   - Getting Started:
@@ -27,8 +27,8 @@ nav:
     - TACC Docs: clients/tacc-docs-example.md
     - DS User Guide: clients/ds-user-guide-example.md
   - Community:
-    - How to Contribute: https://github.com/TACC/Core-Docs/blob/main/CONTRIBUTING.md
-    - Known Clients: https://github.com/TACC/Core-Docs/blob/main/README.md#known-clients
+    - How to Contribute: https://github.com/TACC/mkdocs-tacc/blob/main/CONTRIBUTING.md
+    - Known Clients: https://github.com/TACC/mkdocs-tacc/blob/main/README.md#known-clients
 
 plugins:
   - search


### PR DESCRIPTION
## Overview

Rename repo from `Core-Docs` to `mkdocs-tacc`.

## Notes

This repo will move from @wesleyboar to @TACC.